### PR TITLE
remove whitespace from username

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -208,7 +208,7 @@ pub async fn get_user_data(user: &str, token: String) -> Result<UserData, ErrorR
 
     let now = Utc::now();
     let joined = date_with_just_year(
-        get_join_date(&client, user)
+        get_join_date(&client, user.trim())
             .await
             .map_err(|_| ErrorResponse::from("Something went wrong, try again."))?,
     )

--- a/src/client.rs
+++ b/src/client.rs
@@ -136,7 +136,6 @@ pub async fn get_calendars(
         "
         ))
     }
-
     let req = format!(
         "
         {{
@@ -204,11 +203,11 @@ pub struct UserData {
 }
 
 pub async fn get_user_data(user: &str, token: String) -> Result<UserData, ErrorResponse> {
+    let user = user.trim();
     let client = Octocrab::builder().personal_token(token).build().unwrap();
-
     let now = Utc::now();
     let joined = date_with_just_year(
-        get_join_date(&client, user.trim())
+        get_join_date(&client, user)
             .await
             .map_err(|_| ErrorResponse::from("Something went wrong, try again."))?,
     )


### PR DESCRIPTION
previously, if you searched for a user and added a trailing whitespace it would not find it and throw an error.